### PR TITLE
Align login screen with dark discussion UI

### DIFF
--- a/lib/views/home_page.dart
+++ b/lib/views/home_page.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:chatbot_app/views/discussion_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -24,8 +23,8 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   // Controlleurs pour les champs de texte
-  TextEditingController usernameController = TextEditingController();
-  TextEditingController passwordController = TextEditingController();
+  final TextEditingController usernameController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
   // Message qui apparaît en cas d'erreur
   String messageErreur = "";
 
@@ -132,20 +131,25 @@ class _HomePageState extends State<HomePage> {
         // Popup pour informer l'utilisateur qu'il doit aller valider son inscription dans ses mails
         showDialog(context: context, builder: (context) {
           return AlertDialog(
-            title: const Text("Inscription réussie",
+            backgroundColor: const Color(0xFF111827),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+            title: const Text(
+              "Inscription réussie",
               style: TextStyle(color: Colors.white, fontSize: 20, fontWeight: FontWeight.bold),
             ),
-            content: const Text("Veuillez valider votre comptre via votre email avant de vous connecter.",
-              style: TextStyle(color: Colors.white, fontSize: 16),
+            content: const Text(
+              "Veuillez valider votre comptre via votre email avant de vous connecter.",
+              style: TextStyle(color: Colors.white70, fontSize: 16),
             ),
-            backgroundColor: const Color.fromRGBO(117, 117, 117, 1.0),
+            actionsPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             actions: [
               TextButton(
                 onPressed: () {
                   Navigator.pop(context);
                 },
-                child: const Text("OK",
-                  style: TextStyle(color: Colors.white, fontSize: 16),
+                child: const Text(
+                  "OK",
+                  style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w600),
                 ),
               ),
             ],
@@ -171,106 +175,532 @@ class _HomePageState extends State<HomePage> {
 
 
   @override
+  void dispose() {
+    usernameController.dispose();
+    passwordController.dispose();
+    super.dispose();
+  }
+
+  Color get _backgroundColor => const Color(0xFF0B101A);
+  Color get _panelColor => const Color(0xFF111827);
+  Color get _inputColor => const Color(0xFF1F2937);
+
+  @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color.fromRGBO(59, 59, 63, 1),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            const SizedBox(height: 10),
-            // Logo de l'application
-            Expanded(child: Image.asset("assets/logo.png", width: 320, height: 320)),
+    return GestureDetector(
+      onTap: () => FocusScope.of(context).unfocus(),
+      child: Scaffold(
+        backgroundColor: _backgroundColor,
+        body: SafeArea(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final bool isWide = constraints.maxWidth >= 960;
+              final EdgeInsets horizontalPadding =
+                  EdgeInsets.symmetric(horizontal: isWide ? 64 : 24);
 
-            // Message d'erreur s'il y en a un
-            messageErreur.isNotEmpty ?
-              SizedBox(
-                height: 30,
+              final content = ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 1200),
                 child: Padding(
-                  padding: const EdgeInsets.all(2.0),
-                  child: AutoSizeText(
-                    messageErreur,
-                    maxLines: 1,
-                    maxFontSize: 16,
-                    minFontSize: 8,
-                    style: const TextStyle(color: Colors.red),
+                  padding: EdgeInsets.symmetric(vertical: isWide ? 48 : 24),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      if (!isWide)
+                        _HeaderSection(
+                          backgroundColor: _panelColor,
+                          gradient: _primaryGradient,
+                        ),
+                      Expanded(
+                        child: isWide
+                            ? Row(
+                                children: [
+                                  Expanded(
+                                    child: Padding(
+                                      padding: const EdgeInsets.only(right: 40),
+                                      child: _HeroSection(gradient: _primaryGradient),
+                                    ),
+                                  ),
+                                  Expanded(
+                                    child: Align(
+                                      alignment: Alignment.center,
+                                      child: _AuthCard(
+                                        messageErreur: messageErreur,
+                                        onConnexion: connexion,
+                                        onInscription: inscription,
+                                        usernameController: usernameController,
+                                        passwordController: passwordController,
+                                        panelColor: _panelColor,
+                                        inputColor: _inputColor,
+                                        gradient: _primaryGradient,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              )
+                            : SingleChildScrollView(
+                                child: Column(
+                                  children: [
+                                    const SizedBox(height: 32),
+                                    _AuthCard(
+                                      messageErreur: messageErreur,
+                                      onConnexion: connexion,
+                                      onInscription: inscription,
+                                      usernameController: usernameController,
+                                      passwordController: passwordController,
+                                      panelColor: _panelColor,
+                                      inputColor: _inputColor,
+                                      gradient: _primaryGradient,
+                                    ),
+                                    const SizedBox(height: 32),
+                                    _HeroSection(gradient: _primaryGradient),
+                                  ],
+                                ),
+                              ),
+                      ),
+                    ],
                   ),
                 ),
-              )
-            : const SizedBox(height: 30),
+              );
 
-            // Champ de texte pour l'adresse mail
-            Container(
-              width: 300,
-              height: 50,
-              decoration: BoxDecoration(color: const Color.fromRGBO(85, 85, 85, 1), borderRadius: BorderRadius.circular(25)),
-              child: Center(
-                child: TextField(
-                  controller: usernameController,
-                  decoration: InputDecoration(
-                    hintText: "Adresse Mail",
-                    hintStyle: const TextStyle(color: Colors.white30),
-                    border: InputBorder.none,
-                    contentPadding: const EdgeInsets.symmetric(horizontal: 20),
-                  ),
-                  style: const TextStyle(color: Colors.white, fontSize: 16),
-                  cursorColor: Colors.white,
+              return Center(
+                child: Padding(
+                  padding: horizontalPadding,
+                  child: content,
                 ),
-              ),
-            ),
-
-            SizedBox(height: MediaQuery.of(context).size.height * 0.02),
-
-            // Champ de texte pour le mot de passe
-            Container(
-              width: 300,
-              height: 50,
-              decoration: BoxDecoration(color: const Color.fromRGBO(85, 85, 85, 1), borderRadius: BorderRadius.circular(25)),
-              child: Center(
-                child: TextField(
-                  controller: passwordController,
-                  decoration: InputDecoration(
-                    hintText: "Mot de passe",
-                    hintStyle: const TextStyle(color: Colors.white30),
-                    border: InputBorder.none,
-                    contentPadding: const EdgeInsets.symmetric(horizontal: 20),
-                  ),
-                  style: const TextStyle(color: Colors.white, fontSize: 16),
-                  cursorColor: Colors.white,
-                ),
-              ),
-            ),
-
-            SizedBox(height: MediaQuery.of(context).size.height * 0.05),
-
-            // Bouton de connexion
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: const Color.fromRGBO(85, 85, 85, 1),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(25)),
-                minimumSize: const Size(150, 40),
-              ),
-              onPressed: connexion,
-              child: const Text("Se connecter", style: TextStyle(color: Colors.white30, fontSize: 16)),
-            ),
-
-            SizedBox(height: MediaQuery.of(context).size.height * 0.01),
-
-            // Bouton d'inscription
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: const Color.fromRGBO(85, 85, 85, 1),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(25)),
-                minimumSize: const Size(150, 40),
-              ),
-              onPressed: inscription,
-              child: const Text("S'inscrire", style: TextStyle(color: Colors.white30, fontSize: 16)),
-            ),
-
-            const SizedBox(height: 50),
-          ],
+              );
+            },
+          ),
         ),
+      ),
+    );
+  }
+
+  LinearGradient get _primaryGradient => const LinearGradient(
+        colors: [Color(0xFF2563EB), Color(0xFF7C3AED)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      );
+}
+
+class _HeaderSection extends StatelessWidget {
+  const _HeaderSection({
+    required this.backgroundColor,
+    required this.gradient,
+  });
+
+  final Color backgroundColor;
+  final Gradient gradient;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: Colors.white.withOpacity(0.06)),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: gradient,
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Image.asset('assets/logo.png'),
+            ),
+          ),
+          const SizedBox(width: 16),
+          const Expanded(
+            child: Text(
+              "Bienvenue sur NovaMind",
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 20,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroSection extends StatelessWidget {
+  const _HeroSection({required this.gradient});
+
+  final Gradient gradient;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(32),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(32),
+        gradient: LinearGradient(
+          colors: [
+            Colors.white.withOpacity(0.04),
+            Colors.white.withOpacity(0.01),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        border: Border.all(color: Colors.white.withOpacity(0.05)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ShaderMask(
+            shaderCallback: (Rect bounds) {
+              return gradient.createShader(bounds);
+            },
+            child: const Text(
+              "NovaMind",
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 42,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            "L'assistant conversationnel conçu pour libérer votre créativité.",
+            style: TextStyle(
+              color: Colors.white.withOpacity(0.75),
+              fontSize: 18,
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: const [
+              _FeatureChip(icon: Icons.flash_on_rounded, label: "Réponses instantanées"),
+              _FeatureChip(icon: Icons.auto_awesome_rounded, label: "Idées sur mesure"),
+              _FeatureChip(icon: Icons.lock_rounded, label: "Sécurité renforcée"),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: Colors.black.withOpacity(0.4),
+              borderRadius: BorderRadius.circular(24),
+              border: Border.all(color: Colors.white.withOpacity(0.05)),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 48,
+                  height: 48,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    gradient: gradient,
+                  ),
+                  child: const Icon(Icons.lock_open_rounded, color: Colors.white),
+                ),
+                const SizedBox(width: 20),
+                Expanded(
+                  child: Text(
+                    "Connexion sécurisée via certificat CA pour protéger vos données.",
+                    style: TextStyle(
+                      color: Colors.white.withOpacity(0.7),
+                      fontSize: 16,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AuthCard extends StatelessWidget {
+  const _AuthCard({
+    required this.messageErreur,
+    required this.onConnexion,
+    required this.onInscription,
+    required this.usernameController,
+    required this.passwordController,
+    required this.panelColor,
+    required this.inputColor,
+    required this.gradient,
+  });
+
+  final String messageErreur;
+  final VoidCallback onConnexion;
+  final VoidCallback onInscription;
+  final TextEditingController usernameController;
+  final TextEditingController passwordController;
+  final Color panelColor;
+  final Color inputColor;
+  final Gradient gradient;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 460,
+      padding: const EdgeInsets.symmetric(horizontal: 36, vertical: 40),
+      decoration: BoxDecoration(
+        color: panelColor,
+        borderRadius: BorderRadius.circular(32),
+        border: Border.all(color: Colors.white.withOpacity(0.06)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.4),
+            blurRadius: 40,
+            offset: const Offset(0, 30),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  gradient: gradient,
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(10.0),
+                  child: Image.asset('assets/logo.png'),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    "Ravi de vous revoir",
+                    style: TextStyle(
+                      color: Colors.white.withOpacity(0.85),
+                      fontSize: 16,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  const Text(
+                    "Connectez-vous à votre espace",
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 22,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 32),
+          if (messageErreur.isNotEmpty)
+            Container(
+              width: double.infinity,
+              margin: const EdgeInsets.only(bottom: 24),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              decoration: BoxDecoration(
+                color: Colors.red.withOpacity(0.12),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: Colors.red.withOpacity(0.4)),
+              ),
+              child: Text(
+                messageErreur,
+                style: const TextStyle(
+                  color: Colors.redAccent,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          _InputField(
+            controller: usernameController,
+            label: "Adresse mail",
+            hint: "prenom.nom@email.com",
+            inputColor: inputColor,
+            icon: Icons.alternate_email_rounded,
+          ),
+          const SizedBox(height: 20),
+          _InputField(
+            controller: passwordController,
+            label: "Mot de passe",
+            hint: "••••••••",
+            obscureText: true,
+            inputColor: inputColor,
+            icon: Icons.lock_outline_rounded,
+          ),
+          const SizedBox(height: 28),
+          _GradientButton(
+            onPressed: onConnexion,
+            label: "Se connecter",
+            gradient: gradient,
+          ),
+          const SizedBox(height: 16),
+          OutlinedButton(
+            onPressed: onInscription,
+            style: OutlinedButton.styleFrom(
+              minimumSize: const Size.fromHeight(52),
+              foregroundColor: Colors.white,
+              side: BorderSide(color: Colors.white.withOpacity(0.2)),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+              textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+            ),
+            child: const Text("Créer un compte"),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            "En vous connectant, vous acceptez nos conditions d'utilisation et notre politique de confidentialité.",
+            style: TextStyle(
+              color: Colors.white.withOpacity(0.45),
+              fontSize: 12,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InputField extends StatelessWidget {
+  const _InputField({
+    required this.controller,
+    required this.label,
+    required this.hint,
+    required this.inputColor,
+    this.obscureText = false,
+    this.icon,
+  });
+
+  final TextEditingController controller;
+  final String label;
+  final String hint;
+  final Color inputColor;
+  final bool obscureText;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: TextStyle(
+            color: Colors.white.withOpacity(0.7),
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 10),
+        Container(
+          decoration: BoxDecoration(
+            color: inputColor,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: Colors.white.withOpacity(0.06)),
+          ),
+          child: TextField(
+            controller: controller,
+            obscureText: obscureText,
+            cursorColor: Colors.white,
+            style: const TextStyle(color: Colors.white, fontSize: 16),
+            decoration: InputDecoration(
+              prefixIcon: icon != null
+                  ? Icon(icon, color: Colors.white.withOpacity(0.6))
+                  : null,
+              border: InputBorder.none,
+              hintText: hint,
+              hintStyle: TextStyle(color: Colors.white.withOpacity(0.3)),
+              contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _GradientButton extends StatelessWidget {
+  const _GradientButton({
+    required this.onPressed,
+    required this.label,
+    required this.gradient,
+  });
+
+  final VoidCallback onPressed;
+  final String label;
+  final Gradient gradient;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: gradient,
+        borderRadius: BorderRadius.circular(18),
+        boxShadow: [
+          BoxShadow(
+            color: const Color(0xFF2563EB).withOpacity(0.45),
+            blurRadius: 24,
+            offset: const Offset(0, 12),
+          ),
+        ],
+      ),
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          minimumSize: const Size.fromHeight(52),
+          backgroundColor: Colors.transparent,
+          shadowColor: Colors.transparent,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+          textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+        ),
+        child: Text(label),
+      ),
+    );
+  }
+}
+
+class _FeatureChip extends StatelessWidget {
+  const _FeatureChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.06),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: Colors.white.withOpacity(0.08)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, color: Colors.white.withOpacity(0.75), size: 20),
+          const SizedBox(width: 10),
+          Text(
+            label,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- restyle the login view with the same dark scaffold, gradients, and card motifs as the revamped discussion experience
- add responsive hero messaging, feature highlights, and secure-auth callout to enrich the landing layout on desktop and mobile
- refresh authentication inputs, error state, and actions with elevated styling and consistent palette including the gradient primary button

## Testing
- not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68caad337a3883308e2f0a4c4892e087