### PR TITLE
Add mails page for recent analyses

### DIFF
--- a/lib/views/discussion_page.dart
+++ b/lib/views/discussion_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'mails_page.dart';
 
 import 'package:path/path.dart' as p;
 import 'package:http/http.dart' as http;
@@ -567,7 +568,15 @@ class _DiscussionPageState extends State<DiscussionPage> {
           ),
           const SizedBox(height: 32),
           _buildSidebarIcon(icon: Icons.chat_bubble_outline, active: true),
-          _buildSidebarIcon(icon: Icons.folder_copy_outlined),
+          _buildSidebarIcon(
+            icon: Icons.folder_copy_outlined,
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const MailsPage()),
+              );
+            },
+          ),
           _buildSidebarIcon(icon: Icons.analytics_outlined),
           _buildSidebarIcon(icon: Icons.settings_outlined),
           const Spacer(),
@@ -587,12 +596,16 @@ class _DiscussionPageState extends State<DiscussionPage> {
     );
   }
 
-  Widget _buildSidebarIcon({required IconData icon, bool active = false}) {
+  Widget _buildSidebarIcon({
+    required IconData icon,
+    bool active = false,
+    VoidCallback? onTap,
+  }) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: InkWell(
         borderRadius: BorderRadius.circular(18),
-        onTap: () {},
+        onTap: onTap,
         child: Container(
           width: 48,
           height: 48,

--- a/lib/views/home_page.dart
+++ b/lib/views/home_page.dart
@@ -14,7 +14,7 @@ import '../variables.dart';
 ---------------------------------- */
 
 /// Page d'accueil de l'application
-/// Cette page permet à l'utilisateur de se connecter ou de s'inscrire.
+/// Cette page permet à l'utilisateur de se connecter à son compte.
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
   @override
@@ -100,80 +100,6 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  /// Méthode pour s'inscrire
-  void inscription() async {
-    // Vide le message d'erreur
-    setState(() {
-      messageErreur = "";
-    });
-    // Crée un client HTTP sécurisé
-    final client = await createSecureHttpClient();
-
-    // Prépare l'URL et le corps de la requête
-    final url = Uri.parse('$urlPrefix/register');
-    final body = {
-      "email": usernameController.text,
-      "password": passwordController.text,
-    };
-
-    try {
-      // Envoie la requête POST pour l'inscription
-      final request = await client.postUrl(url);
-      request.headers.set(HttpHeaders.contentTypeHeader, "application/json");
-      request.add(utf8.encode(jsonEncode(body)));
-
-      // Attend la réponse du serveur
-      final response = await request.close();
-
-      if (response.statusCode == 200) {
-        // print("Inscription réussie");
-
-        // Popup pour informer l'utilisateur qu'il doit aller valider son inscription dans ses mails
-        showDialog(context: context, builder: (context) {
-          return AlertDialog(
-            backgroundColor: const Color(0xFF111827),
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
-            title: const Text(
-              "Inscription réussie",
-              style: TextStyle(color: Colors.white, fontSize: 20, fontWeight: FontWeight.bold),
-            ),
-            content: const Text(
-              "Veuillez valider votre comptre via votre email avant de vous connecter.",
-              style: TextStyle(color: Colors.white70, fontSize: 16),
-            ),
-            actionsPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-            actions: [
-              TextButton(
-                onPressed: () {
-                  Navigator.pop(context);
-                },
-                child: const Text(
-                  "OK",
-                  style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w600),
-                ),
-              ),
-            ],
-          );
-        },);
-
-      } else {
-        // Affiche un message d'erreur si l'inscription échoue (erreur envoyée par l'API)
-        //print("Erreur lors de l'inscription : ${response.statusCode}");
-        setState(() {
-          messageErreur = "Erreur lors de l'inscription : ${response.statusCode}";
-        });
-
-      }
-    } catch (e) {
-      // Gère les exceptions et affiche un message d'erreur (erreur de connexion, problème de certificat, etc.)
-      //print("Exception pendant l'inscription : $e");
-      setState(() {
-        messageErreur = "Erreur pendant l'inscription.";
-      });
-    }
-  }
-
-
   @override
   void dispose() {
     usernameController.dispose();
@@ -192,324 +118,70 @@ class _HomePageState extends State<HomePage> {
       child: Scaffold(
         backgroundColor: _backgroundColor,
         body: SafeArea(
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              final bool isWide = constraints.maxWidth >= 960;
-              final EdgeInsets horizontalPadding =
-                  EdgeInsets.symmetric(horizontal: isWide ? 64 : 24);
-
-              final content = ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 1200),
-                child: Padding(
-                  padding: EdgeInsets.symmetric(vertical: isWide ? 48 : 24),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      if (!isWide)
-                        _HeaderSection(
-                          backgroundColor: _panelColor,
-                          gradient: _primaryGradient,
-                        ),
-                      Expanded(
-                        child: isWide
-                            ? Row(
-                                children: [
-                                  Expanded(
-                                    child: Padding(
-                                      padding: const EdgeInsets.only(right: 40),
-                                      child: _HeroSection(gradient: _primaryGradient),
-                                    ),
-                                  ),
-                                  Expanded(
-                                    child: Align(
-                                      alignment: Alignment.center,
-                                      child: _AuthCard(
-                                        messageErreur: messageErreur,
-                                        onConnexion: connexion,
-                                        onInscription: inscription,
-                                        usernameController: usernameController,
-                                        passwordController: passwordController,
-                                        panelColor: _panelColor,
-                                        inputColor: _inputColor,
-                                        gradient: _primaryGradient,
-                                      ),
-                                    ),
-                                  ),
-                                ],
-                              )
-                            : SingleChildScrollView(
-                                child: Column(
-                                  children: [
-                                    const SizedBox(height: 32),
-                                    _AuthCard(
-                                      messageErreur: messageErreur,
-                                      onConnexion: connexion,
-                                      onInscription: inscription,
-                                      usernameController: usernameController,
-                                      passwordController: passwordController,
-                                      panelColor: _panelColor,
-                                      inputColor: _inputColor,
-                                      gradient: _primaryGradient,
-                                    ),
-                                    const SizedBox(height: 32),
-                                    _HeroSection(gradient: _primaryGradient),
-                                  ],
-                                ),
-                              ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-
-              return Center(
-                child: Padding(
-                  padding: horizontalPadding,
-                  child: content,
-                ),
-              );
-            },
+          child: Center(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+              child: _AuthCard(
+                messageErreur: messageErreur,
+                onConnexion: connexion,
+                usernameController: usernameController,
+                passwordController: passwordController,
+                panelColor: _panelColor,
+                inputColor: _inputColor,
+              ),
+            ),
           ),
         ),
       ),
     );
   }
 
-  LinearGradient get _primaryGradient => const LinearGradient(
-        colors: [Color(0xFF2563EB), Color(0xFF7C3AED)],
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-      );
-}
-
-class _HeaderSection extends StatelessWidget {
-  const _HeaderSection({
-    required this.backgroundColor,
-    required this.gradient,
-  });
-
-  final Color backgroundColor;
-  final Gradient gradient;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-      decoration: BoxDecoration(
-        color: backgroundColor,
-        borderRadius: BorderRadius.circular(24),
-        border: Border.all(color: Colors.white.withOpacity(0.06)),
-      ),
-      child: Row(
-        children: [
-          Container(
-            width: 48,
-            height: 48,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              gradient: gradient,
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Image.asset('assets/logo.png'),
-            ),
-          ),
-          const SizedBox(width: 16),
-          const Expanded(
-            child: Text(
-              "Bienvenue sur NovaMind",
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 20,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _HeroSection extends StatelessWidget {
-  const _HeroSection({required this.gradient});
-
-  final Gradient gradient;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(32),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(32),
-        gradient: LinearGradient(
-          colors: [
-            Colors.white.withOpacity(0.04),
-            Colors.white.withOpacity(0.01),
-          ],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-        border: Border.all(color: Colors.white.withOpacity(0.05)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          ShaderMask(
-            shaderCallback: (Rect bounds) {
-              return gradient.createShader(bounds);
-            },
-            child: const Text(
-              "NovaMind",
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 42,
-                fontWeight: FontWeight.w800,
-              ),
-            ),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            "L'assistant conversationnel conçu pour libérer votre créativité.",
-            style: TextStyle(
-              color: Colors.white.withOpacity(0.75),
-              fontSize: 18,
-              height: 1.4,
-            ),
-          ),
-          const SizedBox(height: 24),
-          Wrap(
-            spacing: 12,
-            runSpacing: 12,
-            children: const [
-              _FeatureChip(icon: Icons.flash_on_rounded, label: "Réponses instantanées"),
-              _FeatureChip(icon: Icons.auto_awesome_rounded, label: "Idées sur mesure"),
-              _FeatureChip(icon: Icons.lock_rounded, label: "Sécurité renforcée"),
-            ],
-          ),
-          const SizedBox(height: 24),
-          Container(
-            padding: const EdgeInsets.all(20),
-            decoration: BoxDecoration(
-              color: Colors.black.withOpacity(0.4),
-              borderRadius: BorderRadius.circular(24),
-              border: Border.all(color: Colors.white.withOpacity(0.05)),
-            ),
-            child: Row(
-              children: [
-                Container(
-                  width: 48,
-                  height: 48,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    gradient: gradient,
-                  ),
-                  child: const Icon(Icons.lock_open_rounded, color: Colors.white),
-                ),
-                const SizedBox(width: 20),
-                Expanded(
-                  child: Text(
-                    "Connexion sécurisée via certificat CA pour protéger vos données.",
-                    style: TextStyle(
-                      color: Colors.white.withOpacity(0.7),
-                      fontSize: 16,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
 }
 
 class _AuthCard extends StatelessWidget {
   const _AuthCard({
     required this.messageErreur,
     required this.onConnexion,
-    required this.onInscription,
     required this.usernameController,
     required this.passwordController,
     required this.panelColor,
     required this.inputColor,
-    required this.gradient,
   });
 
   final String messageErreur;
   final VoidCallback onConnexion;
-  final VoidCallback onInscription;
   final TextEditingController usernameController;
   final TextEditingController passwordController;
   final Color panelColor;
   final Color inputColor;
-  final Gradient gradient;
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 460,
-      padding: const EdgeInsets.symmetric(horizontal: 36, vertical: 40),
+      width: 360,
+      padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 32),
       decoration: BoxDecoration(
         color: panelColor,
-        borderRadius: BorderRadius.circular(32),
-        border: Border.all(color: Colors.white.withOpacity(0.06)),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.4),
-            blurRadius: 40,
-            offset: const Offset(0, 30),
-          ),
-        ],
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: Colors.white.withOpacity(0.08)),
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            children: [
-              Container(
-                width: 56,
-                height: 56,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  gradient: gradient,
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(10.0),
-                  child: Image.asset('assets/logo.png'),
-                ),
-              ),
-              const SizedBox(width: 16),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    "Ravi de vous revoir",
-                    style: TextStyle(
-                      color: Colors.white.withOpacity(0.85),
-                      fontSize: 16,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  const Text(
-                    "Connectez-vous à votre espace",
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 22,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ],
-              ),
-            ],
+          const Text(
+            "Connexion",
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+            ),
           ),
-          const SizedBox(height: 32),
+          const SizedBox(height: 24),
           if (messageErreur.isNotEmpty)
             Container(
               width: double.infinity,
-              margin: const EdgeInsets.only(bottom: 24),
+              margin: const EdgeInsets.only(bottom: 20),
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
               decoration: BoxDecoration(
                 color: Colors.red.withOpacity(0.12),
@@ -527,45 +199,38 @@ class _AuthCard extends StatelessWidget {
             ),
           _InputField(
             controller: usernameController,
-            label: "Adresse mail",
-            hint: "prenom.nom@email.com",
+            label: "Identifiant",
+            hint: "Entrez votre identifiant",
             inputColor: inputColor,
-            icon: Icons.alternate_email_rounded,
+            icon: Icons.person_outline,
           ),
           const SizedBox(height: 20),
           _InputField(
             controller: passwordController,
             label: "Mot de passe",
-            hint: "••••••••",
-            obscureText: true,
+            hint: "Entrez votre mot de passe",
             inputColor: inputColor,
+            obscureText: true,
             icon: Icons.lock_outline_rounded,
           ),
           const SizedBox(height: 28),
-          _GradientButton(
-            onPressed: onConnexion,
-            label: "Se connecter",
-            gradient: gradient,
-          ),
-          const SizedBox(height: 16),
-          OutlinedButton(
-            onPressed: onInscription,
-            style: OutlinedButton.styleFrom(
-              minimumSize: const Size.fromHeight(52),
-              foregroundColor: Colors.white,
-              side: BorderSide(color: Colors.white.withOpacity(0.2)),
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
-              textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
-            ),
-            child: const Text("Créer un compte"),
-          ),
-          const SizedBox(height: 24),
-          Text(
-            "En vous connectant, vous acceptez nos conditions d'utilisation et notre politique de confidentialité.",
-            style: TextStyle(
-              color: Colors.white.withOpacity(0.45),
-              fontSize: 12,
-              height: 1.4,
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: onConnexion,
+              style: ElevatedButton.styleFrom(
+                minimumSize: const Size.fromHeight(48),
+                backgroundColor: const Color(0xFF2563EB),
+                foregroundColor: Colors.white,
+                textStyle: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+              ),
+              child: const Text('Se connecter'),
             ),
           ),
         ],
@@ -632,76 +297,3 @@ class _InputField extends StatelessWidget {
   }
 }
 
-class _GradientButton extends StatelessWidget {
-  const _GradientButton({
-    required this.onPressed,
-    required this.label,
-    required this.gradient,
-  });
-
-  final VoidCallback onPressed;
-  final String label;
-  final Gradient gradient;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        gradient: gradient,
-        borderRadius: BorderRadius.circular(18),
-        boxShadow: [
-          BoxShadow(
-            color: const Color(0xFF2563EB).withOpacity(0.45),
-            blurRadius: 24,
-            offset: const Offset(0, 12),
-          ),
-        ],
-      ),
-      child: ElevatedButton(
-        onPressed: onPressed,
-        style: ElevatedButton.styleFrom(
-          minimumSize: const Size.fromHeight(52),
-          backgroundColor: Colors.transparent,
-          shadowColor: Colors.transparent,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
-          textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
-        ),
-        child: Text(label),
-      ),
-    );
-  }
-}
-
-class _FeatureChip extends StatelessWidget {
-  const _FeatureChip({required this.icon, required this.label});
-
-  final IconData icon;
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
-      decoration: BoxDecoration(
-        color: Colors.white.withOpacity(0.06),
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: Colors.white.withOpacity(0.08)),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, color: Colors.white.withOpacity(0.75), size: 20),
-          const SizedBox(width: 10),
-          Text(
-            label,
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 14,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}

--- a/lib/views/mails_page.dart
+++ b/lib/views/mails_page.dart
@@ -1,0 +1,365 @@
+import 'package:flutter/material.dart';
+
+import '../variables.dart';
+
+/* ----------------------------------
+  Projet 4A : Chatbot App
+  Date : 11/06/2025
+  mails_page.dart
+---------------------------------- */
+
+class MailsPage extends StatelessWidget {
+  const MailsPage({super.key});
+
+  Color get _backgroundColor => const Color(0xFF0B101A);
+  Color get _panelColor => const Color(0xFF111827);
+
+  static final List<_MailAnalysis> _recentMails = [
+        _MailAnalysis(
+          subject: 'Suspicious login detected',
+          analyzedAt: DateTime(2025, 1, 12, 9, 24),
+          maliciousnessScore: 78,
+        ),
+        _MailAnalysis(
+          subject: 'Invoice #54213 attached',
+          analyzedAt: DateTime(2025, 1, 12, 8, 55),
+          maliciousnessScore: 22,
+        ),
+        _MailAnalysis(
+          subject: 'Password reset confirmation',
+          analyzedAt: DateTime(2025, 1, 11, 19, 41),
+          maliciousnessScore: 12,
+        ),
+        _MailAnalysis(
+          subject: 'Security alert from IT team',
+          analyzedAt: DateTime(2025, 1, 11, 18, 2),
+          maliciousnessScore: 65,
+        ),
+        _MailAnalysis(
+          subject: 'Daily marketing report',
+          analyzedAt: DateTime(2025, 1, 11, 16, 45),
+          maliciousnessScore: 8,
+        ),
+        _MailAnalysis(
+          subject: 'Verify your new device',
+          analyzedAt: DateTime(2025, 1, 11, 15, 12),
+          maliciousnessScore: 48,
+        ),
+      ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: _backgroundColor,
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final bool isWide = constraints.maxWidth >= 900;
+            final mailContent = _buildMailContent(isWide);
+
+            if (isWide) {
+              return Row(
+                children: [
+                  _PrimarySidebar(
+                    activeIndex: 1,
+                    onChatPressed: () => Navigator.of(context).maybePop(),
+                    onMailsPressed: null,
+                  ),
+                  Expanded(child: mailContent),
+                ],
+              );
+            }
+
+            return Column(
+              children: [
+                _PrimarySidebar(
+                  activeIndex: 1,
+                  isHorizontal: true,
+                  onChatPressed: () => Navigator.of(context).maybePop(),
+                  onMailsPressed: null,
+                ),
+                Expanded(child: mailContent),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMailContent(bool isWide) {
+    return Container(
+      color: _backgroundColor,
+      padding: EdgeInsets.symmetric(
+        horizontal: isWide ? 48 : 24,
+        vertical: isWide ? 48 : 28,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Mails analysés récemment',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 28,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Consultez les derniers rapports générés par le serveur.',
+            style: TextStyle(
+              color: Colors.white.withOpacity(0.7),
+              fontSize: 15,
+            ),
+          ),
+          const SizedBox(height: 32),
+          Expanded(
+            child: ListView.separated(
+              physics: const BouncingScrollPhysics(),
+              itemCount: _recentMails.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 18),
+              itemBuilder: (context, index) {
+                final mail = _recentMails[index];
+                return _MailCard(
+                  mail: mail,
+                  panelColor: _panelColor,
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PrimarySidebar extends StatelessWidget {
+  const _PrimarySidebar({
+    required this.activeIndex,
+    this.isHorizontal = false,
+    this.onChatPressed,
+    this.onMailsPressed,
+  });
+
+  final int activeIndex;
+  final bool isHorizontal;
+  final VoidCallback? onChatPressed;
+  final VoidCallback? onMailsPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final children = <Widget>[
+      _SidebarIcon(
+        icon: Icons.chat_bubble_outline,
+        active: activeIndex == 0,
+        onTap: onChatPressed,
+      ),
+      _SidebarIcon(
+        icon: Icons.folder_copy_outlined,
+        active: activeIndex == 1,
+        onTap: onMailsPressed,
+      ),
+      _SidebarIcon(icon: Icons.analytics_outlined),
+      _SidebarIcon(icon: Icons.settings_outlined),
+      const Spacer(),
+      Container(
+        margin: const EdgeInsets.only(bottom: 12, top: 12),
+        child: CircleAvatar(
+          radius: 22,
+          backgroundColor: const Color(0xFF1F2937),
+          child: Text(
+            user.username.isNotEmpty ? user.username[0].toUpperCase() : '?',
+            style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+          ),
+        ),
+      ),
+    ];
+
+    if (isHorizontal) {
+      return Container(
+        height: 88,
+        decoration: const BoxDecoration(color: Color(0xFF0F172A)),
+        child: Row(
+          children: [
+            const SizedBox(width: 24),
+            _buildLogo(),
+            const SizedBox(width: 24),
+            ...children,
+            const SizedBox(width: 24),
+          ],
+        ),
+      );
+    }
+
+    return Container(
+      width: 88,
+      decoration: BoxDecoration(
+        color: const Color(0xFF0F172A),
+        border: Border(
+          right: BorderSide(color: Colors.white.withOpacity(0.05)),
+        ),
+      ),
+      child: Column(
+        children: [
+          const SizedBox(height: 24),
+          _buildLogo(),
+          const SizedBox(height: 32),
+          ...children,
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLogo() {
+    return Container(
+      width: 48,
+      height: 48,
+      decoration: BoxDecoration(
+        color: const Color(0xFF1F2937),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(10),
+        child: Image.asset('assets/logo.png', fit: BoxFit.contain),
+      ),
+    );
+  }
+}
+
+class _SidebarIcon extends StatelessWidget {
+  const _SidebarIcon({
+    required this.icon,
+    this.active = false,
+    this.onTap,
+  });
+
+  final IconData icon;
+  final bool active;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 6),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(18),
+        onTap: onTap,
+        child: Container(
+          width: 48,
+          height: 48,
+          decoration: BoxDecoration(
+            color: active ? const Color(0xFF1F2937) : Colors.transparent,
+            borderRadius: BorderRadius.circular(18),
+            border: Border.all(
+              color: active ? Colors.white.withOpacity(0.25) : Colors.white.withOpacity(0.06),
+            ),
+          ),
+          child: Icon(icon, color: active ? Colors.white : Colors.white60),
+        ),
+      ),
+    );
+  }
+}
+
+class _MailCard extends StatelessWidget {
+  const _MailCard({required this.mail, required this.panelColor});
+
+  final _MailAnalysis mail;
+  final Color panelColor;
+
+  String get formattedDate {
+    final day = mail.analyzedAt.day.toString().padLeft(2, '0');
+    final month = mail.analyzedAt.month.toString().padLeft(2, '0');
+    final year = mail.analyzedAt.year.toString();
+    final hour = mail.analyzedAt.hour.toString().padLeft(2, '0');
+    final minute = mail.analyzedAt.minute.toString().padLeft(2, '0');
+    return '$day/$month/$year à $hour:$minute';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: panelColor,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: Colors.white.withOpacity(0.06)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.2),
+            blurRadius: 12,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: const Color(0xFF1F2937),
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: const Icon(Icons.mail_outline, color: Colors.white70),
+          ),
+          const SizedBox(width: 20),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  mail.subject,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Date d\'analyse : $formattedDate',
+                  style: TextStyle(
+                    color: Colors.white.withOpacity(0.7),
+                    fontSize: 14,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF1F2937),
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: Colors.white.withOpacity(0.08)),
+                  ),
+                  child: Text(
+                    'Score of maliciousness : ${mail.maliciousnessScore}%',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MailAnalysis {
+  const _MailAnalysis({
+    required this.subject,
+    required this.analyzedAt,
+    required this.maliciousnessScore,
+  });
+
+  final String subject;
+  final DateTime analyzedAt;
+  final int maliciousnessScore;
+}


### PR DESCRIPTION
## Summary
- add a dedicated mails page that mirrors the chat theme and lists recent server analyses with scrolling support
- wire the folder sidebar icon to open the mails page and allow sidebar icons to accept optional actions

## Testing
- not run (flutter CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d395990ab48330804cb94fdf32b018