### PR TITLE
Adjust UI layout per feedback

### DIFF
--- a/lib/views/discussion_page.dart
+++ b/lib/views/discussion_page.dart
@@ -1190,7 +1190,7 @@ class _DiscussionPageState extends State<DiscussionPage> {
                     ],
                   ),
                 ),
-                if (isLoading)
+                if (isWide && isLoading)
                   _buildStatusChip(palette, 'Réponse en cours...'),
                 if (!isWide) const SizedBox(width: 8),
                 _buildHeaderAction(

--- a/lib/views/mails_page.dart
+++ b/lib/views/mails_page.dart
@@ -288,35 +288,30 @@ class _MailCard extends StatelessWidget {
                           ),
                         ),
                         const SizedBox(height: 10),
-                        Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Expanded(
-                              child: Text(
-                                mail.summary,
-                                style: TextStyle(
-                                  color: palette.textSecondary,
-                                  fontSize: 13.5,
-                                  height: 1.35,
-                                ),
-                              ),
-                            ),
-                            if (isWide && onStartConversation != null) ...[
-                              const SizedBox(width: 16),
-                              _ConversationButton(
-                                palette: palette,
-                                onPressed: onStartConversation!,
-                              ),
-                            ],
-                          ],
+                        Text(
+                          mail.summary,
+                          style: TextStyle(
+                            color: palette.textSecondary,
+                            fontSize: 13.5,
+                            height: 1.35,
+                          ),
                         ),
                       ],
                     ),
                   ),
                   const SizedBox(width: 12),
-                  Align(
-                    alignment: Alignment.topRight,
-                    child: _ScoreBadge(palette: palette, score: mail.maliciousnessScore),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      _ScoreBadge(palette: palette, score: mail.maliciousnessScore),
+                      if (isWide && onStartConversation != null) ...[
+                        const SizedBox(height: 12),
+                        _ConversationButton(
+                          palette: palette,
+                          onPressed: onStartConversation!,
+                        ),
+                      ],
+                    ],
                   ),
                 ],
               ),

--- a/lib/views/widgets/primary_navigation.dart
+++ b/lib/views/widgets/primary_navigation.dart
@@ -128,16 +128,13 @@ class PrimaryNavigation extends StatelessWidget {
   }
 
   Widget _buildLogo() {
-    return Container(
+    return SizedBox(
       width: 48,
       height: 48,
-      decoration: BoxDecoration(
-        color: palette.mutedSurface,
-        borderRadius: BorderRadius.circular(16),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(10),
-        child: Image.asset('assets/logo.png', fit: BoxFit.contain),
+      child: Image.asset(
+        'assets/logo.png',
+        fit: BoxFit.contain,
+        filterQuality: FilterQuality.high,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- hide the chat "Réponse en cours" chip on narrow layouts
- align the desktop mail conversation button beneath the score column
- remove the navigation logo background and scale the logo up to fill the previous padding

## Testing
- `flutter analyze` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d56c0500c8833081052f9466a179f1